### PR TITLE
fix(parser): 解析命中缓存时仍同步图片到 asset_save_dir

### DIFF
--- a/paper_reading/pdf_parser.py
+++ b/paper_reading/pdf_parser.py
@@ -5,6 +5,7 @@
 """
 
 import os
+import shutil
 import uuid
 from pathlib import Path
 
@@ -57,11 +58,15 @@ class MineRUParser:
 
     @time_it("mineru parser")
     @cache_it(key_generator=key_generator)
-    def parse(self, file_path: str, asset_save_dir: str = "") -> list[Content]:
-        """解析 PDF 文件，返回 Content 列表。
+    def _parse_cached(self, file_path: str) -> list[Content]:
+        """运行 MineRU 解析 PDF，返回 Content 列表（按 PDF 内容缓存）。
 
-        使用 MineRU pipeline 后端解析，图片写入 asset_save_dir。
-        content_url 存储绝对路径，供 steps.py 生成 Obsidian wikilink。
+        图片始终写入 PDF 同级的 ``<stem>_images`` 目录——该目录按内容寻址、
+        稳定可复用，充当图片的持久源；content_url 记录其中图片的绝对路径。
+
+        本方法只负责「纯解析」，不接受 asset_save_dir。把图片落地到指定资源
+        目录是带副作用的操作，由 parse() 负责并保证每次都执行，否则缓存命中时
+        副作用会被一并跳过，导致「命中缓存即丢图」。
         """
         _setup_mineru_env(self.model_source, self.device)
 
@@ -73,10 +78,7 @@ class MineRUParser:
         pdf_path = Path(file_path).resolve()
         pdf_bytes = pdf_path.read_bytes()
 
-        if asset_save_dir:
-            image_dir = str(Path(asset_save_dir).resolve())
-        else:
-            image_dir = str(pdf_path.parent / (pdf_path.stem + "_images"))
+        image_dir = str(pdf_path.parent / (pdf_path.stem + "_images"))
         os.makedirs(image_dir, exist_ok=True)
 
         image_writer = FileBasedDataWriter(image_dir)
@@ -108,6 +110,46 @@ class MineRUParser:
         contents = self._convert_to_contents(content_list_raw, file_path)
         Logger.info(f"Parsed {len(contents)} content items from {pdf_path.name}")
         return contents
+
+    def parse(self, file_path: str, asset_save_dir: str = "") -> list[Content]:
+        """解析 PDF 文件，返回 Content 列表。
+
+        MineRU 解析（重计算）按 PDF 内容缓存；把图片落地到 asset_save_dir 的
+        副作用每次都会执行，因此即便解析命中缓存，图片仍会同步到目标目录，
+        steps.py 生成的 Obsidian wikilink 不会指向缺失文件。
+        """
+        contents = self._parse_cached(file_path)
+        if asset_save_dir:
+            self._materialize_assets(contents, asset_save_dir)
+        return contents
+
+    @staticmethod
+    def _materialize_assets(contents: list[Content], asset_save_dir: str) -> None:
+        """把 contents 引用的图片复制到 asset_save_dir，并改写 content_url 指向它。
+
+        幂等：目标已存在则跳过复制。该操作与解析缓存解耦、每次调用都执行，
+        确保图片落到资源目录（如 Obsidian attachments），wikilink 才能渲染。
+        源文件缺失（例如 PDF 同级 ``*_images`` 目录被删）时记录警告并跳过。
+        """
+        dst = Path(asset_save_dir).resolve()
+        dst.mkdir(parents=True, exist_ok=True)
+        for content in contents:
+            src = content.content_url
+            if not src:
+                continue
+            target = dst / os.path.basename(src)
+            if target.exists():
+                content.content_url = str(target)
+                continue
+            if os.path.isfile(src):
+                shutil.copy2(src, target)
+                content.content_url = str(target)
+            else:
+                Logger.warning(
+                    f"Asset source missing, cannot materialize: {src}. "
+                    "若需重新生成图片，请删除该 PDF 同级的 *_images 目录"
+                    "或清理解析缓存后重试。"
+                )
 
     def _convert_to_contents(
         self,

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,0 +1,83 @@
+"""Tests for MineRUParser asset materialization.
+
+聚焦验证：解析结果命中缓存时，图片仍会被同步到 asset_save_dir，
+content_url 被改写为目标路径——即修复「命中缓存即丢图」。
+"""
+
+from pathlib import Path
+
+from paper_reading.config import Content, ContentType
+from paper_reading.pdf_parser import MineRUParser
+
+
+def _make_image_content(img_path: Path) -> Content:
+    return Content(
+        content_type=ContentType.IMAGE,
+        file_path="dummy.pdf",
+        content="",
+        extra_description="",
+        content_url=str(img_path),
+    )
+
+
+def test_materialize_copies_assets_and_rewrites_url(tmp_path) -> None:
+    src_dir = tmp_path / "paper_images"
+    src_dir.mkdir()
+    img = src_dir / "abc123.jpg"
+    img.write_bytes(b"\xff\xd8\xff\xd9")  # minimal jpeg-ish bytes
+
+    contents = [_make_image_content(img)]
+    dst = tmp_path / "attachments"
+
+    MineRUParser._materialize_assets(contents, str(dst))
+
+    copied = dst / "abc123.jpg"
+    assert copied.is_file()
+    assert copied.read_bytes() == b"\xff\xd8\xff\xd9"
+    # content_url 改写为目标目录中的路径，basename 不变 -> wikilink 一致
+    assert contents[0].content_url == str(copied.resolve())
+
+
+def test_materialize_is_idempotent(tmp_path) -> None:
+    src_dir = tmp_path / "paper_images"
+    src_dir.mkdir()
+    img = src_dir / "abc123.jpg"
+    img.write_bytes(b"original")
+
+    dst = tmp_path / "attachments"
+    dst.mkdir()
+    # 目标已存在且内容不同：幂等跳过复制，不覆盖
+    (dst / "abc123.jpg").write_bytes(b"existing")
+
+    contents = [_make_image_content(img)]
+    MineRUParser._materialize_assets(contents, str(dst))
+
+    assert (dst / "abc123.jpg").read_bytes() == b"existing"
+    assert contents[0].content_url == str((dst / "abc123.jpg").resolve())
+
+
+def test_materialize_skips_missing_source(tmp_path) -> None:
+    missing = tmp_path / "paper_images" / "gone.jpg"
+    contents = [_make_image_content(missing)]
+    dst = tmp_path / "attachments"
+
+    # 源缺失时不抛异常、不创建目标，content_url 保持原值
+    MineRUParser._materialize_assets(contents, str(dst))
+
+    assert not (dst / "gone.jpg").exists()
+    assert contents[0].content_url == str(missing)
+
+
+def test_materialize_ignores_content_without_url(tmp_path) -> None:
+    text = Content(
+        content_type=ContentType.TEXT,
+        file_path="dummy.pdf",
+        content="hello",
+        extra_description="",
+        content_url="",
+    )
+    dst = tmp_path / "attachments"
+
+    MineRUParser._materialize_assets([text], str(dst))
+
+    assert text.content_url == ""


### PR DESCRIPTION
## 问题

解析同一个 PDF 时，图片有时不会出现在 `asset_save_dir`（如 Obsidian `attachments`），导致生成的 `![[xxx.jpg]]` wikilink 指向缺失文件、无法渲染。

根因是缓存与副作用耦合：`parse()` 把「用 MineRU 的 `image_writer` 把图片写到 `asset_save_dir`」这个**副作用**放进了被 `@cache_it` 缓存的函数体里，而缓存 key（`key_generator`）只含 PDF 内容哈希、不含 `asset_save_dir`。于是重复解析同一 PDF 时：

- 缓存命中 → 函数体整段跳过（这也是为什么重跑只要几秒而非几分钟）
- 写图片的副作用一并被跳过 → 图片从未落到 `asset_save_dir`
- 返回的 `content_url` 仍指向首次解析的目录，basename 取出来生成 wikilink，但物理文件不在 vault 里 → 渲染失败

## 改动

拆分「纯计算」与「副作用」：

- `_parse_cached()`：只做 MineRU 解析并缓存，图片固定写入 PDF 同级的 `<stem>_images`（内容寻址、稳定，充当图片持久源）。
- `parse()`：调用 `_parse_cached()` 后，由新增的 `_materialize_assets()` 把引用图片复制到 `asset_save_dir` 并改写 `content_url`。**该副作用与缓存解耦、每次调用都执行且幂等**。

副作用：

- ✅ MineRU 重计算仍只跑一次、按 PDF 内容缓存，快速重跑优势保留。
- ✅ 对**既有缓存条目**同样生效——`content_url` 指向旧 `_images`，`_materialize_assets()` 直接从那里补齐图片，**无需清缓存或重跑 MineRU**。
- ✅ `parse()` 公共签名不变，basename 不变 → 生成的 wikilink 完全一致。

边界：若 PDF 同级 `*_images` 目录被手动删除，缓存命中时源文件缺失 → 记录警告并跳过（提示删除 `*_images` 或清缓存后重试）。

## 测试

新增 `tests/test_pdf_parser.py`，覆盖 `_materialize_assets` 的：复制并改写 url、幂等不覆盖、源缺失安全跳过、无 url 内容忽略。

```
9 passed in 0.11s
ruff: All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
