### PR TITLE
fix: 声明 six 依赖并容错 surrogate 字符写盘

### DIFF
--- a/paper_reading/pipeline.py
+++ b/paper_reading/pipeline.py
@@ -95,7 +95,10 @@ async def process(params: ProcessParams) -> ProcessResult:
         llm_endpoint=params.llm_endpoint,
         llm_api_key=params.llm_api_key,
     )
-    with open(md_file_path, "w") as md_writer:
+    # errors="replace": MineRU 从部分 PDF 抽取的文本可能含非法 surrogate 码点，
+    # 严格 UTF-8 编码会在写盘时抛 "surrogates not allowed" 并中断输出，
+    # 用替换策略容错，保证整篇 Markdown 写完。
+    with open(md_file_path, "w", encoding="utf-8", errors="replace") as md_writer:
         ctx.md_writer = md_writer
         md_writer.write(f"{name_without_suff}" + line_breaker)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paper-reading"
-version = "0.1.0"
+version = "0.1.1"
 description = "A PDF processing pipeline for academic papers with summarization and translation"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -12,6 +12,7 @@ dependencies = [
     "modelscope>=1.36.2",
     "openai>=1.109.1",
     "pydantic>=2.0.0",
+    "six",
     "tiktoken",
     "xxhash",
 ]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,46 @@
+"""回归测试：写出含非法 surrogate 码点的 Markdown 不应崩溃。
+
+MineRU 从部分 PDF 抽取的文本可能带孤立 surrogate（如 '\\ud83d'），严格
+UTF-8 编码会在写盘时抛 "surrogates not allowed" 并中断输出。process() 用
+errors="replace" 容错，保证整篇 Markdown 写完且可正常读回。
+"""
+
+import asyncio
+
+from paper_reading import pipeline
+from paper_reading.config import ProcessParams, Step
+
+
+def test_process_writes_surrogate_without_crashing(tmp_path, monkeypatch) -> None:
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 dummy")
+    out = tmp_path / "out"
+
+    # 避免触发真实 MineRU 解析
+    monkeypatch.setattr(pipeline, "parse_pdf", lambda **kwargs: [])
+
+    surrogate_text = "前缀\ud83d后缀"  # 孤立 high surrogate，无法严格 UTF-8 编码
+
+    async def _fake_original(ctx) -> None:
+        ctx.md_writer.write(surrogate_text)
+
+    monkeypatch.setattr(pipeline, "STEP_REGISTRY", {Step.ORIGINAL: _fake_original})
+
+    params = ProcessParams(
+        file_path=str(pdf),
+        output_dir=str(out),
+        steps=["original"],
+    )
+
+    # 修复前这里会抛 UnicodeEncodeError: surrogates not allowed
+    result = asyncio.run(pipeline.process(params))
+
+    md = out / "paper.md"
+    assert md.is_file()
+    assert result.output_file == str(md)
+
+    # 能正常读回（不抛 UnicodeDecodeError），非法 surrogate 已被替换
+    content = md.read_text(encoding="utf-8")
+    assert "前缀" in content
+    assert "后缀" in content
+    assert "\ud83d" not in content

--- a/uv.lock
+++ b/uv.lock
@@ -1484,7 +1484,7 @@ wheels = [
 
 [[package]]
 name = "paper-reading"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -1493,6 +1493,7 @@ dependencies = [
     { name = "modelscope" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "six" },
     { name = "strenum" },
     { name = "tiktoken" },
     { name = "xxhash" },
@@ -1512,6 +1513,7 @@ requires-dist = [
     { name = "modelscope", specifier = ">=1.36.2" },
     { name = "openai", specifier = ">=1.109.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "six" },
     { name = "strenum" },
     { name = "tiktoken" },
     { name = "xxhash" },


### PR DESCRIPTION
修复两个导致 `digest-to-md` 解析失败的问题。

## 改动点
- **缺失 `six`**:运行时被间接依赖但无人声明,全新 `uv tool install` 会漏装,导致 MineRU 解析抛 `No module named 'six'`。在 `pyproject.toml` 显式声明 `six`。
- **surrogate 写盘崩溃**:MineRU 从部分 PDF 抽取的文本含孤立 surrogate 码点,严格 UTF-8 编码在写 Markdown 时抛 `'utf-8' codec can't encode ... surrogates not allowed` 并截断输出。输出 `open()` 改用 `encoding="utf-8", errors="replace"` 容错,保证整篇写完。
- 版本 `0.1.0 → 0.1.1`。

## 测试
- 新增 `tests/test_pipeline.py`:覆盖含孤立 surrogate 的 Markdown 写入回归(修复前会抛 `surrogates not allowed`)。
- `uv run pytest -q` → 10 passed;`uv run ruff check` → 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)